### PR TITLE
fixed static name issues

### DIFF
--- a/ham/ham.php
+++ b/ham/ham.php
@@ -4,7 +4,7 @@ class Ham {
 
     public $routes;
     public $config;
-    public static $name;
+    public $name;
     public $cache;
     public $logger;
     public $parent;
@@ -262,16 +262,30 @@ class Ham {
     }
 
     /**
-     * Cancel application
-     * @param $code
+     * static version of abort
+     * to allow for calling of abort by class
+     * @param integer $code
+     * @param string $message
+     * @param Ham $app
+     * @return string
+     */
+    public static function _abort($code, $message='',$app=null) {
+        if(php_sapi_name() != 'cli')
+            header("Status: {$code}", False, $code);
+        $name = !is_null($app) ? 
+                $app->name : 
+                'App not set, call this function from the app or explicitly pass the $app as the last argument';
+        return "<h1>{$code}</h1><p>{$message}</p><p>{$name}</p>";
+    }
+
+    /**
+     * application specific Cancel method
+     * @param integer $code
      * @param string $message
      * @return string
      */
-    public static function abort($code, $message='') {
-        if(php_sapi_name() != 'cli')
-            header("Status: {$code}", False, $code);
-        $name = self::$name;
-        return "<h1>{$code}</h1><p>{$message}</p><p>{$name}</p>";
+    public function abort($code,$message=''){
+        return self::_abort($code,$message,$this);
     }
 
     /**

--- a/tests/HamTest.php
+++ b/tests/HamTest.php
@@ -133,4 +133,14 @@ class HamTest extends PHPUnit_Framework_TestCase {
             $this->assertEquals($match, 1);
         }
     }
+    public function testAbortHasName(){
+        $app = $this->app;
+        $this->assertContains($app->name,$app->abort(401,'error'));    
+    }
+
+    public function testStaticAbortHasNoName(){
+        $app = $this->app;
+        $cls = get_class($app);
+        $this->assertContains('App not set, call this function from the app or explicitly pass the $app as the last argument',$cls::_abort(404,'error'));
+    }
 }


### PR DESCRIPTION
i noticed that changing the $name instance var to static screwed up some tests, so im sure it made trouble for someone out there, this is my solution to allow for static calling of the abort function while still allowing us to know what app is aborting, because abort isnt of much use unless we know what app aborted, so now the static and non-static functions have been seperated into static::_abort and non-static abort, static::_abort now takes an $app as its last argument, this is what it uses to resolve the value for $name, so you can still call Ham::_abort but you need to pass your aborting app as the last argument or it will yell at you. Conversley to make life easy, you can just call $app->abort($code,$msg); to get the standard abort, with $app implictly passed to Ham::_abort. Also expanded tests to reflect this change.